### PR TITLE
Implement tags page

### DIFF
--- a/controllers/store.controller.js
+++ b/controllers/store.controller.js
@@ -72,3 +72,12 @@ exports.getStoreBySlug = async (req, res) => {
   const store = await Store.findOne({ slug: storeSlug })
   res.render('store', { title: store.name, store })
 }
+
+exports.getStoresByTag = async (req, res) => {
+  const currentTag = req.params.tag
+  const tagQuery = currentTag || { $exists: true }
+  const tagsGroupsPromise = Store.getTagsList()
+  const storesPromise = Store.find({ tags: tagQuery })
+  const [tagsGroups, stores] = await Promise.all([tagsGroupsPromise, storesPromise])
+  res.render('tags', { title: 'Tags', tags: tagsGroups, stores, currentTag })
+}

--- a/models/Store.js
+++ b/models/Store.js
@@ -49,4 +49,21 @@ storeSchema.pre('save', async function (next) {
   next()
 })
 
+storeSchema.statics.getTagsList = function () {
+  return this.aggregate([
+    { $unwind: '$tags' },
+    {
+      $group: {
+        _id: '$tags',
+        count: { $sum: 1 }
+      }
+    },
+    {
+      $sort: {
+        count: -1
+      }
+    }
+  ])
+}
+
 module.exports = mongoose.model('Store', storeSchema)

--- a/routes/index.js
+++ b/routes/index.js
@@ -28,4 +28,7 @@ router.route('/stores/:id')
 // Show the store by slug
 router.get('/store/:slug', asyncMiddleware(storeController.getStoreBySlug))
 
+// Show stores by tag
+router.get('/tags/:tag?', asyncMiddleware(storeController.getStoresByTag))
+
 module.exports = router

--- a/views/tags.pug
+++ b/views/tags.pug
@@ -1,0 +1,18 @@
+extends layout
+
+include mixins/_storeCard
+
+block content
+  .inner
+    h2= currentTag || 'Tags'
+
+    ul.tags
+      each t in tags
+        li.tag
+          a.tag__link(href=`/tags/${t._id}`, class=(t._id === currentTag ? 'tag__link--active' : ''))
+            span.tag__text= t._id
+            span.tag__count= t.count
+
+    .stores
+      each store in stores
+        +storeCard(store)


### PR DESCRIPTION
Show stores based on a currently selected tag, or all stores (for the root ‘/tags’ route) containing at least one tag.